### PR TITLE
refactor: extend node/fee endpoint with 'days' parameter

### DIFF
--- a/Client/Client/Api/Endpoints/Node.swift
+++ b/Client/Client/Api/Endpoints/Node.swift
@@ -42,8 +42,8 @@ public class Node {
         apiGetHandler("\(endpoint)/configuration/crypto", [:], completionHandler)
     }
 
-    /// Retrieves the fees
-    public func fees(completionHandler: @escaping ([String: Any]?) -> Void) {
-        apiGetHandler("\(endpoint)/fees", [:], completionHandler)
+    /// Retrieves the fee statistics
+    public func fees(completionHandler: @escaping ([String: Any]?) -> Void, days: Int? = nil) {
+        apiGetHandler("\(endpoint)/fees", ["days": days], completionHandler)
     }
 }

--- a/Client/ClientTests/Api/Endpoints/NodeTest.swift
+++ b/Client/ClientTests/Api/Endpoints/NodeTest.swift
@@ -81,4 +81,18 @@ class NodeTest: XCTestCase {
         XCTAssert(parameters?.count == 0)
     }
 
+    func testNodeFees() {
+        let expectation = self.expectation(description: "Get node fee statistics")
+        var response: [String: Any]?
+        node?.fees(completionHandler: { (res) in
+            response = res
+            expectation.fulfill()
+        })
+        waitForExpectations(timeout: 5, handler: nil)
+
+        let parameters = response!["parameters"] as! [String: Any]?
+        XCTAssert(response!["url"] as! String == "\(self.apiEndpoint)/fees" )
+        XCTAssert(parameters?.count == 0)
+    }
+
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Refactors the `node/fees` function so that it accepts an optional `days` argument.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
